### PR TITLE
Rename executeHooks(...) to executeHook(...)

### DIFF
--- a/gitbucket-githooks-plugin/src/main/scala/io/github/gitbucket/githooks/helpers/HookExecutor.scala
+++ b/gitbucket-githooks-plugin/src/main/scala/io/github/gitbucket/githooks/helpers/HookExecutor.scala
@@ -16,7 +16,7 @@ import java.io.{File, FileReader, BufferedReader}
 import java.nio.file.{Files, Paths}
 
 object HookExecutor {
-    def executeHooks(hook: String, owner: String, repositoryName: String, branchName: String, sha: String, commitMessage: String, commitUserName: String, pusher: String, repositoryDir: String, config: org.eclipse.jgit.lib.Config) {
+    def executeHook(hook: String, owner: String, repositoryName: String, branchName: String, sha: String, commitMessage: String, commitUserName: String, pusher: String, repositoryDir: String, config: org.eclipse.jgit.lib.Config) {
             val CONFIG_CORE_KEY = org.eclipse.jgit.lib.ConfigConstants.CONFIG_CORE_SECTION
             val HOOKS_PATH_KEY  = org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_HOOKS_PATH
             

--- a/gitbucket-githooks-plugin/src/main/scala/io/github/gitbucket/githooks/hook/CommitHook.scala
+++ b/gitbucket-githooks-plugin/src/main/scala/io/github/gitbucket/githooks/hook/CommitHook.scala
@@ -38,7 +38,7 @@ class CommitHook extends ReceiveHook with RepositoryService with AccountService 
 
                     val config = git.getRepository().getConfig()
 
-                    HookExecutor.executeHooks(
+                    HookExecutor.executeHook(
                         hook = "post-receive",
                         owner = owner, 
                         repositoryName = repository, 

--- a/gitbucket-githooks-plugin/src/main/scala/io/github/gitbucket/githooks/hook/PRHook.scala
+++ b/gitbucket-githooks-plugin/src/main/scala/io/github/gitbucket/githooks/hook/PRHook.scala
@@ -47,7 +47,7 @@ class PRHook extends PullRequestHook
 
             val pusher = if (currentLoggedInAccount != null) currentLoggedInAccount.userName else ""
 
-            HookExecutor.executeHooks(
+            HookExecutor.executeHook(
                 hook = "post-receive",
                 owner = repository.owner,
                 repositoryName = pullRequest.repositoryName,


### PR DESCRIPTION
This PR renames HookExecutor.executeHooks(...) to HookExecutor.executeHook(...).  See #1 .

It doesn't really make a difference, but it makes more sense since the function only executes one hook per call.