### PR TITLE
update to gitbucket 4.35.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,11 @@ This plugin *can* be dangerous if used improperly. But my thought is: if someone
 Keep in mind that the Git hooks are executable scripts and can perform essentially any action if given the proper access. Think `sudo rm -rf /` ... I can only imagine what that would do to your server.
 
 **To limit actions available in the script, look into limiting the user that is running the server.**
+
+## Versions Table
+
+Plugin version | GitBucket version
+:--------------|:--------------------
+1.1.0          | 4.35.x
+1.0.0          | 4.33.x
+

--- a/gitbucket-githooks-plugin/build.sbt
+++ b/gitbucket-githooks-plugin/build.sbt
@@ -1,15 +1,10 @@
 name := "gitbucket-githooks-plugin"
 organization := "io.github.gitbucket"
-version := "0.1.1"
-scalaVersion := "2.13.1"
+version := "1.1.0"
+scalaVersion := "2.13.5"
+gitbucketVersion := "4.35.3"
 
-libraryDependencies ++= Seq(
-  "io.github.gitbucket" %% "gitbucket"         % "4.33.0" % "provided",
-  "javax.servlet"        % "javax.servlet-api" % "3.1.0" % "provided"
-)
+scalacOptions := Seq("-deprecation", "-feature", "-language:postfixOps")
+Compile / javacOptions ++= Seq("-target", "8", "-source", "8")
 
-resolvers ++= Seq(
-  Classpaths.typesafeReleases,
-  Resolver.jcenterRepo,
-  "sonatype-snapshot" at "https://oss.sonatype.org/content/repositories/snapshots/"
-)
+useJCenter := true

--- a/gitbucket-githooks-plugin/project/build.properties
+++ b/gitbucket-githooks-plugin/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version = 1.5.0

--- a/gitbucket-githooks-plugin/project/metals.sbt
+++ b/gitbucket-githooks-plugin/project/metals.sbt
@@ -1,4 +1,4 @@
 // DO NOT EDIT! This file is auto-generated.
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1-229-b7c15aa9")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8-19-4d9f966b")

--- a/gitbucket-githooks-plugin/project/plugins.sbt
+++ b/gitbucket-githooks-plugin/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.github.gitbucket" % "sbt-gitbucket-plugin" % "1.5.1")

--- a/gitbucket-githooks-plugin/src/main/scala/Plugin.scala
+++ b/gitbucket-githooks-plugin/src/main/scala/Plugin.scala
@@ -7,7 +7,10 @@ class Plugin extends gitbucket.core.plugin.Plugin {
   override val pluginName: String = "Git Hooks Plugin"
 
   override val description: String = "A plugin that enables the existing .git/hooks functionality."
-  override val versions: List[Version] = List(new Version("0.1.1"))
+  override val versions: List[Version] = List(
+    new Version("1.0.0"),
+    new Version("1.1.0")
+  )
 
   override val receiveHooks: Seq[ReceiveHook] = Seq(new io.github.gitbucket.githook.hook.CommitHook())
   override val pullRequestHooks: Seq[PullRequestHook] = Seq(new io.github.gitbucket.githook.hook.PRHook())

--- a/gitbucket-githooks-plugin/src/main/scala/io/github/gitbucket/githooks/helpers/HookExecutor.scala
+++ b/gitbucket-githooks-plugin/src/main/scala/io/github/gitbucket/githooks/helpers/HookExecutor.scala
@@ -16,7 +16,7 @@ import java.io.{File, FileReader, BufferedReader}
 import java.nio.file.{Files, Paths}
 
 object HookExecutor {
-    def executeHook(hook: String, owner: String, repositoryName: String, branchName: String, sha: String, commitMessage: String, commitUserName: String, pusher: String, repositoryDir: String, config: org.eclipse.jgit.lib.Config) {
+    def executeHook(hook: String, owner: String, repositoryName: String, branchName: String, sha: String, commitMessage: String, commitUserName: String, pusher: String, repositoryDir: String, config: org.eclipse.jgit.lib.Config): Unit = {
             val CONFIG_CORE_KEY = org.eclipse.jgit.lib.ConfigConstants.CONFIG_CORE_SECTION
             val HOOKS_PATH_KEY  = org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_HOOKS_PATH
             

--- a/gitbucket-githooks-plugin/src/main/scala/io/github/gitbucket/githooks/hook/CommitHook.scala
+++ b/gitbucket-githooks-plugin/src/main/scala/io/github/gitbucket/githooks/hook/CommitHook.scala
@@ -26,7 +26,7 @@ import io.github.gitbucket.githook.helpers.HookExecutor
 
 */
 class CommitHook extends ReceiveHook with RepositoryService with AccountService with CommitStatusService with SystemSettingsService {
-    override def postReceive(owner: String, repository: String, receivePack: ReceivePack, command: ReceiveCommand, pusher: String)(implicit session: Session): Unit = {
+    override def postReceive(owner: String, repository: String, receivePack: ReceivePack, command: ReceiveCommand, pusher: String, mergePullRequest: Boolean)(implicit session: Session): Unit = {
         val branch = command.getRefName.stripPrefix("refs/heads/")
         val repositoryDir = getRepositoryDir(owner, repository)
 

--- a/gitbucket-githooks-plugin/src/main/scala/io/github/gitbucket/githooks/hook/PRHook.scala
+++ b/gitbucket-githooks-plugin/src/main/scala/io/github/gitbucket/githooks/hook/PRHook.scala
@@ -22,7 +22,7 @@ import io.github.gitbucket.githook.helpers.HookExecutor
 
 class PRHook extends PullRequestHook
   with PullRequestService with IssuesService with CommitsService with AccountService with WebHookService
-  with WebHookPullRequestService with WebHookPullRequestReviewCommentService with ActivityService with MergeService
+  with WebHookPullRequestService with WebHookPullRequestReviewCommentService with ActivityService with RequestCache with MergeService
   with RepositoryService with LabelsService with PrioritiesService with MilestonesService {
     override def merged(issue: Issue, repository: RepositoryInfo)(implicit session: Session, context: Context): Unit = {
         if (issue.isPullRequest) {


### PR DESCRIPTION
GitBucket version 4.35 is out as of Jan 13, 2021. This PR updates to that version.
